### PR TITLE
Fix crash caused by removal of PartThumb folders

### DIFF
--- a/AllowedPlacesUtility/FormMain.cs
+++ b/AllowedPlacesUtility/FormMain.cs
@@ -114,10 +114,13 @@ namespace APU
             ListViewItem lvi = new ListViewItem();
             lvi.Text = c.Name;
             lvi.Tag = c;
-            IEnumerable<string> files = Directory.EnumerateFiles(carpath + "\\PartThumb\\", "*-car*");
-            if (files.Count() > 0)
+            if (Directory.Exists(carpath + "\\PartThumb"))
             {
-                c.Image = Image.FromFile(files.FirstOrDefault());
+                IEnumerable<string> files = Directory.EnumerateFiles(carpath + "\\PartThumb\\", "*-car*");
+                if (files.Count() > 0)
+                {
+                    c.Image = Image.FromFile(files.FirstOrDefault());
+                }
             }
             lvwCars.Items.Add(lvi);
         }


### PR DESCRIPTION
This fixes the crash caused by the developers removing the PartThumb folders, albeit those cars will not show thumbnails in app. Any cars which still have the folder will be shown.