### PR TITLE
Fix notfound.jpg error

### DIFF
--- a/AllowedPlacesUtility/FormMain.cs
+++ b/AllowedPlacesUtility/FormMain.cs
@@ -124,7 +124,7 @@ namespace APU
             }
             else
             {
-                c.Image = Image.FromFile("notfound.jpg");
+                c.Image = Properties.Resources.notfound;
             }
             lvwCars.Items.Add(lvi);
         }


### PR DESCRIPTION
Loading the notfound image through project resources avoids the System.IO error when PartThumbs folder is not present.